### PR TITLE
Jhony/fix poc filter enrollments

### DIFF
--- a/edunext_openedx_extensions/__init__.py
+++ b/edunext_openedx_extensions/__init__.py
@@ -1,4 +1,4 @@
 """
 init for main app
 """
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/edunext_openedx_extensions/microsite_aware_functions/enrollments.py
+++ b/edunext_openedx_extensions/microsite_aware_functions/enrollments.py
@@ -12,7 +12,9 @@ def filter_enrollments(enrollments):
 
     # If we do not have a microsite context, there is nothing we can do
     if not microsite.is_request_in_microsite():
-        return enrollments
+        for enrollment in enrollments:
+            yield enrollment
+        return
 
     orgs_to_include = microsite.get_value('course_org_filter')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 


### PR DESCRIPTION
This PR is a Hotfix related with the change applied in [this commit](https://github.com/eduNEXT/edunext-openedx-extensions/commit/b9b91aa507e7df45242528a24409e2576c512235). Basically we cannot use return with a value to exit a generator (more details [https://stackoverflow.com/questions/15809296/python-syntaxerror-return-with-argument-inside-generator](url)). To solve this, I returned the enrollments as a generator.

@diegomillan 
@felipemontoya 