### PR TITLE
Fmo/default in settings call

### DIFF
--- a/edunext_openedx_extensions/__init__.py
+++ b/edunext_openedx_extensions/__init__.py
@@ -1,4 +1,4 @@
 """
 init for main app
 """
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/edunext_openedx_extensions/edunext/middleware.py
+++ b/edunext_openedx_extensions/edunext/middleware.py
@@ -64,7 +64,7 @@ class MicrositeMiddleware(object):
 
         # By this time, if there is no redirect, and no microsite, the domain is available
         if (not microsite.is_request_in_microsite() and
-                settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] and
+                settings.FEATURES.get('USE_MICROSITE_AVAILABLE_SCREEN', False) and
                 not bool(HOST_VALIDATION_RE.search(domain))):
             return HttpResponseNotFound(edxmako.shortcuts.render_to_string('microsites/not_found.html', {
                 'domain': domain,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 


### PR DESCRIPTION
Description
--------------
This PR switches to False the default to use USE_MICROSITE_AVAILABLE_SCREEN when it does not exists in settings.

For edxapp we set it to true in common.py, and to False in testing. This PR fixes some of the failing tests at https://circleci.com/gh/eduNEXT/edunext-platform/634#tests/containers/1

Reviewers
-------------
- [ ] @morenol 

Post approve
-----------------
- [x] Bumpversion patch
