### PR TITLE
CrossBrandingFilter resilience

### DIFF
--- a/edunext_openedx_extensions/ednx_microsites/middleware.py
+++ b/edunext_openedx_extensions/ednx_microsites/middleware.py
@@ -13,6 +13,7 @@ import re
 from django.conf import settings
 from django.http import Http404
 
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from microsite_configuration import microsite  # pylint: disable=import-error
 
@@ -70,7 +71,10 @@ class MicrositeCrossBrandingFilterMiddleware():
             return None
 
         course_id = matched_regex.group('course_id')
-        course_key = CourseKey.from_string(course_id)
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            raise Http404
 
         # If the course org is the same as the current microsite
         org_filter = microsite.get_value('course_org_filter', set([]))


### PR DESCRIPTION
Description
========

When the CrossBrandingFilter does not find a key, it will return 404

Motivation
========

We have been encountering errors in production that arise from malformed urls. 
For example  `/courses/course-v1:edX%20DemoX%20Demo_Course/courseware/interactive_demonstrations/19a30717eff543078a5d94ae9d6c18a5/` produces a 500 error, when in reality is just a malformed url and should fail silently.
In more detailed the error here is that %20 is the encoded '` `' instead of the %2B which is the '+' sign.